### PR TITLE
Swap added/removed around

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,15 +42,15 @@ function printText(changes, options) {
   Object.entries(changes).forEach(([name, [oldVersion, newVersion]]) => {
     if (!oldVersion) {
       if (options.color) {
-        console.log(`${name} ${chalk.red('removed')}`);
-      } else {
-        console.log(`${name} removed`);
-      }
-    } else if (!newVersion) {
-      if (options.color) {
         console.log(`${name} ${chalk.green('added')}`);
       } else {
         console.log(`${name} added`);
+      }
+    } else if (!newVersion) {
+      if (options.color) {
+        console.log(`${name} ${chalk.red('removed')}`);
+      } else {
+        console.log(`${name} removed`);
       }
     } else if (!semver.eq(oldVersion, newVersion)) {
       if (options.color) {


### PR DESCRIPTION
Lock diff said `added` when packages are `removed` and `removed` packages are `added`.

This swaps around the checks, if `oldVersion` is `null` that meant the lock went from not referencing a package, to referencing it, aka it was an addition, not a removal.

Closes #19